### PR TITLE
Add periodic timer event

### DIFF
--- a/watchtower/alert/consumers/__init__.py
+++ b/watchtower/alert/consumers/__init__.py
@@ -15,6 +15,9 @@ class AbstractConsumer:
     def handle_error(self, error):
         pass
 
+    @abc.abstractmethod
+    def handle_timer(self, now):
+        pass
 
 # When adding a consumer here, also add to _init_plugins method in
 # watchtower.alert.consumer.py

--- a/watchtower/alert/consumers/database.py
+++ b/watchtower/alert/consumers/database.py
@@ -160,3 +160,6 @@ class DatabaseConsumer(AbstractConsumer):
                 conn.execute(ins)
             except sqlalchemy.exc.IntegrityError:
                 logging.warn("Error insert failed (maybe it already exists?)")
+
+    def handle_timer(self, now):
+        pass

--- a/watchtower/alert/consumers/log.py
+++ b/watchtower/alert/consumers/log.py
@@ -29,3 +29,5 @@ class LogConsumer(AbstractConsumer):
                                              error.message)
         logging.error(log_str)
 
+    def handle_timer(self, now):
+        logging.info("TIMER: periodic timer fired at %d" % now)

--- a/watchtower/alert/consumers/timeseries.py
+++ b/watchtower/alert/consumers/timeseries.py
@@ -88,8 +88,6 @@ class TimeseriesConsumer(AbstractConsumer):
             state['int_start'] = this_int_start
             return
         if this_int_start <= state['int_start']:
-            # current interval. flush anyway to get partial results
-            state['kp'].flush(state['int_start'])
             return
 
         while state['int_start'] < this_int_start:
@@ -102,3 +100,10 @@ class TimeseriesConsumer(AbstractConsumer):
     def handle_error(self, error):
         pass
 
+    def handle_timer(self, now):
+        logging.debug("Flushing all KPs...")
+        # flush the kps
+        for name in self.alert_state:
+            logging.debug("Flushing KP for %s" % name)
+            state = self.alert_state[name]
+            state['kp'].flush(state['int_start'])

--- a/watchtower/alert/consumers/traceroute.py
+++ b/watchtower/alert/consumers/traceroute.py
@@ -40,3 +40,5 @@ class TracerouteConsumer(AbstractConsumer):
     def handle_error(self, error):
         pass  # we don't care about errors
 
+    def handle_timer(self, now):
+        pass


### PR DESCRIPTION
This lets the timeseries consumer occasionally flush its key packages ensuring metrics are up-to-date even if alerts are not being receieved
